### PR TITLE
Implement timer for removing out of bounds units

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,3 +1,12 @@
+// Erase all out of bounds units every 2 seconds.
+Timer.schedule(() => {
+    Groups.unit.each(u => {
+        if(u.x !== u.x){
+            u.remove();
+        }
+    });
+}, 0, 2);
+
 let cols = [Pal.lancerLaser, Pal.accent, Color.valueOf("cc6eaf")]; //Pink from BetaMindy
 let folded = false;
 let curSpeed = 0;


### PR DESCRIPTION
Time Control is known for "glitching" units: sending them out of bounds forever, ruining save files. This PR removes these glitched units. This is an upgrade over the last recommendation [here](https://discord.com/channels/391020510269669376/414179246693679124/1472828290522808491).